### PR TITLE
Revert "fix: local workspace issue"

### DIFF
--- a/src/common/utilities/node/host.ts
+++ b/src/common/utilities/node/host.ts
@@ -1,5 +1,8 @@
 import * as os from 'os';
+import {isLocalWorkspace} from '../vscode';
 
-export function isMacOS(): boolean {
-  return os.platform() === 'darwin';
+const isMacOS = os.platform() === 'darwin';
+
+export function isLocalMacOS(): boolean {
+  return isMacOS && isLocalWorkspace();
 }

--- a/src/common/utilities/vscode.ts
+++ b/src/common/utilities/vscode.ts
@@ -3,6 +3,13 @@ import * as vscodeUri from 'vscode-uri';
 
 export const UriUtils = vscodeUri.Utils;
 
+export function isLocalWorkspace(): boolean {
+  return (
+    vscode.workspace.workspaceFolders !== undefined &&
+    vscode.workspace.workspaceFolders.every(f => f.uri.scheme === 'file')
+  );
+}
+
 export function getConfiguration<T>(
   id: string,
   defaultValue?: T

--- a/src/core/binary/binary_plist_editor_provider.ts
+++ b/src/core/binary/binary_plist_editor_provider.ts
@@ -6,7 +6,7 @@ import {replaceTab} from '../../common/utilities/tab';
 import {generatedFileUri} from '../../common/generated_files';
 import {isBinaryPlist} from './decoder/binary_plist_decoder';
 import {getConfiguration, UriUtils} from '../../common/utilities/vscode';
-import {isMacOS} from '../../common/utilities/host';
+import {isLocalMacOS} from '../../common/utilities/host';
 import {generateTextualPlist, exportTextualPlist} from './decoder';
 import {BinaryPlistDocument} from './binary_plist_document';
 import {MANIFEST} from '../manifest';
@@ -26,7 +26,7 @@ export class BinaryPlistEditorProvider
 {
   static get usingMacosDecoder(): boolean {
     return (
-      isMacOS() &&
+      isLocalMacOS() &&
       getConfiguration('plist.binarySupport.decoder', 'plutil') === 'plutil'
     );
   }
@@ -36,7 +36,6 @@ export class BinaryPlistEditorProvider
     private readonly tracker: GeneratedFileTracker
   ) {
     super();
-
     this.disposables.push(...this.performRegistrations());
   }
 
@@ -59,8 +58,7 @@ export class BinaryPlistEditorProvider
         await generateTextualPlist(
           document,
           token,
-          BinaryPlistEditorProvider.usingMacosDecoder &&
-            this.storageLocation.scheme === 'vscode-userdata:'
+          BinaryPlistEditorProvider.usingMacosDecoder
         );
         webviewPanel.webview.html = `Readable plist was generated at ${document.generatedUri}.`;
       } catch (err) {
@@ -96,7 +94,7 @@ export class BinaryPlistEditorProvider
         this
       ),
     ];
-    if (isMacOS()) {
+    if (isLocalMacOS()) {
       registrations.push(
         vscode.workspace.onDidSaveTextDocument(xmlDoc => {
           if (!BinaryPlistEditorProvider.usingMacosDecoder) return;


### PR DESCRIPTION
Reverts cunneen/vscode-plist#6

Compile issue when running `npm run compile-ui`:

```
  [tsl] ERROR in /Users/me/Development/vscode-plist/src/core/binary/binary_plist_editor_provider.ts(9,9)
        TS2305: Module '"../../common/utilities/host"' has no exported member 'isMacOS'.
```