### PR TITLE
Remove unneeded activation events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,5 @@
 {
   "activationEvents": [
-    "onCommand:plistEditor.clearCaches",
-    "onCustomEditor:plistEditor.bplistedit",
-    "onCustomEditor:plistEditor.plistedit",
-    "onCustomEditor:plistEditor.provisioningProfileEdit",
     "onLanguage:plist"
   ],
   "author": {


### PR DESCRIPTION
This prevents the following problems in VS Code v1.75.0+:
```
This activation event can be removed as VS Code generates these automatically from your package.json contribution declarations.
```